### PR TITLE
Subdirectory deployment

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -3,14 +3,16 @@ from flask_babel import get_locale, _
 from webtodotxt import app, auth
 from helpers import *
 import todotxtio
+import os
 
 
 @app.route('/')
 @auth.login_required
 def home():
     locale = get_locale()
+    FORCE_ROOT_URL = os.getenv('WEBTODOTXT_FORCE_ROOT_URL', None)
 
-    return render_template('app.html', first_week_day=locale.first_week_day + 1)
+    return render_template('app.html', first_week_day=locale.first_week_day + 1, force_root_url=FORCE_ROOT_URL)
 
 
 @app.route('/todo.txt', methods=['GET', 'POST'])

--- a/templates/app.html
+++ b/templates/app.html
@@ -145,7 +145,7 @@
         Vue.config.silent = {{ 'false' if config['DEBUG'] else 'true' }};
         Vue.config.productionTip = false;
 
-        ROOT_URL = '{{ request.url_root }}';
+        ROOT_URL = '{{ force_root_url if force_root_url else request.url_root }}';
 
         moment.locale('{{ g.CURRENT_LOCALE }}');
 

--- a/webtodotxt.py
+++ b/webtodotxt.py
@@ -3,13 +3,15 @@ from flask_httpauth import HTTPBasicAuth
 from flask_babel import Babel
 from flask import Flask
 import logging
+import os
 
 
 # -----------------------------------------------------------
 # Boot
 
+STATIC_URL_PATH = os.getenv('WEBTODOTXT_STATIC_URL_PATH', '')
 
-app = Flask(__name__, static_url_path='')
+app = Flask(__name__, static_url_path=STATIC_URL_PATH)
 app.config.from_pyfile('config.py')
 
 if not app.config['TITLE']:


### PR DESCRIPTION
Hello,
with the changes in this PR i am able to deploy webtodotxt in a subpath, e.g. https://asdf.nextcloud.example.de/todotxt/

I implemented the changes in a way that the default values are not changed if there were no environment variables given.

This PR is going to fix #24 

JFYI:
Now, my docker command to deploy it like that is:

`docker create --name $CONTAINERNAME -p 3006:9000 -e SECRET_KEY=supersecret -e AUTH_BACKEND=WebDavAuth -e STORAGE_BACKEND=WebDav -e TODO_FILE_PATH=/remote.php/webdav/todo.txt -e WEBDAV_HOST=https://asdf.nextcloud.example.de -e WEBTODOTXT_STATIC_URL_PATH=/todotxt-static -e WEBTODOTXT_FORCE_ROOT_URL=https://asdf.nextcloud.example.de/todotxt/ strubbl_webtodotxt`


My nginx config looks like that:
```
        location /todotxt-static {                                                                                                                                                                                                                            
          rewrite /todotxt-static(/.*) https://asdf.nextcloud.example.de/todotxt/todotxt-static$1 break;                                                                                                                                                                
        }                                                                                                                                                                                                                                                     
        location /todotxt/ {                                                                                                                                                                                                                                  
          proxy_pass http://127.0.0.1:3006/;                                                                                                                                                                                                                  
          proxy_set_header Host $host;                                                                                                                                                                                                                        
          proxy_set_header X-Real-IP $remote_addr;                                                                                                                                                                                                            
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;                                                                                                                                                                                        
          proxy_set_header X-Scheme $scheme;                                                                                                                                                                                                                  
        }
```
